### PR TITLE
Create task queue alternatives: WrappedSequence and WrappedTaskGroup

### DIFF
--- a/SwiftAdditions/Classes/Additions/TaskQueue.swift
+++ b/SwiftAdditions/Classes/Additions/TaskQueue.swift
@@ -6,6 +6,7 @@ extension Task where Success == Never, Failure == Never {
     }
 }
 
+@available(iOS, introduced: 1.0.0, deprecated: 1.0.1, message: "Operation and async Task are not compatible, causing problems when working with high number of items. Use `WrappedSequence` or `WrappedTaskGroup` instead")
 public class TaskQueue<U> {
     public init(queue: OperationQueue = .init()) {
         self.queue = queue

--- a/SwiftAdditions/Classes/Additions/WrappedSequence.swift
+++ b/SwiftAdditions/Classes/Additions/WrappedSequence.swift
@@ -1,0 +1,70 @@
+public class WrappedTask<U> {
+    public init(block: @escaping @Sendable () async -> Result<U, Error>) {
+        self.block = block
+    }
+
+    let block: @Sendable () async -> Result<U, Error>
+
+    public func execute() async -> Result<U, Error> {
+        if isCancelled {
+            return .failure(CancellationError())
+        }
+
+        let result = await block()
+        isDone = true
+        return result
+    }
+
+    public var isCancelled = false
+    public var isDone = false
+
+    public func cancel() {
+        isCancelled = true
+    }
+}
+
+public class WrappedSequence<U>: AsyncSequence {
+    public init(results: [Result<U, Error>] = [Result<U, Error>](), tasks: [WrappedTask<U>] = [WrappedTask<U>]()) {
+        self.results = results
+        self.tasks = tasks
+    }
+
+    public typealias Element = Result<U, any Error>
+    private var results = [Result<U, Error>]()
+    var tasks = [WrappedTask<U>]()
+
+    public class WrappedIterator: AsyncIteratorProtocol {
+        internal init(iterator: IndexingIterator<[WrappedTask<U>]>) {
+            self.iterator = iterator
+        }
+
+        private var iterator: IndexingIterator<[WrappedTask<U>]>
+
+        public func next() async -> Result<U, Error>? {
+            await iterator.next()?.execute()
+        }
+    }
+
+    public func makeAsyncIterator() -> WrappedIterator {
+        WrappedIterator(iterator: tasks.makeIterator())
+    }
+
+    @discardableResult
+    public func addTask(priority: TaskPriority? = nil, operation: @escaping @Sendable () async -> Result<U, Error>) -> WrappedTask<U> {
+        let task = WrappedTask<U>(block: operation)
+        tasks.append(task)
+        return task
+    }
+
+    public func cancelAll() {
+        tasks.forEach { $0.cancel() }
+    }
+
+    public func getResults() async -> [Result<U, Error>] {
+        var results = [Result<U, Error>]()
+        for await value in self {
+            results.append(value)
+        }
+        return results
+    }
+}

--- a/SwiftAdditions/Classes/Additions/WrappedTaskGroup.swift
+++ b/SwiftAdditions/Classes/Additions/WrappedTaskGroup.swift
@@ -1,0 +1,15 @@
+public struct WrappedTaskGroup {
+
+    public static func run<U>(_ groupReady: (inout ThrowingTaskGroup<U, Error>) -> Void) async throws -> [U] {
+        try await withThrowingTaskGroup(of: U.self) { group in
+            groupReady(&group)
+            var results = [U]()
+
+            for try await value in group {
+                results.append(value)
+            }
+
+            return results
+        }
+    }
+}

--- a/SwiftAdditions/Tests/Additions.xctestplan
+++ b/SwiftAdditions/Tests/Additions.xctestplan
@@ -13,9 +13,6 @@
   },
   "testTargets" : [
     {
-      "skippedTests" : [
-        "TaskQueueTests"
-      ],
       "target" : {
         "containerPath" : "container:",
         "identifier" : "AdditionsTests",

--- a/SwiftAdditions/Tests/TaskQueueTests.swift
+++ b/SwiftAdditions/Tests/TaskQueueTests.swift
@@ -40,11 +40,11 @@ final class TaskQueueTests: XCTestCase {
         XCTAssertEqual(expected, results)
     }
 
-    func disabledTestConcurrentQueueItems() async {
+    func flakyTestConcurrentQueueItems() async {
         let operationQueue = OperationQueue()
         let queue = TaskQueue<Int>(queue: operationQueue)
 
-        let iterations = 20
+        let iterations = 10
         var results = [Int]()
         var expected = [Int]()
         var expectations = [XCTestExpectation]()
@@ -66,9 +66,9 @@ final class TaskQueueTests: XCTestCase {
         XCTAssertEqual(expected.count, results.count) // all items are returned
     }
 
-    func disabledtestConcurrentQueueItemsWithCancellations() async {
+    func flakyTestConcurrentQueueItemsWithCancellations() async {
         let queue = TaskQueue<Int>()
-        let iterations = (1...20)
+        let iterations = (1...10)
         var results = [Int]()
         var expected = [Int]()
 
@@ -76,11 +76,12 @@ final class TaskQueueTests: XCTestCase {
         var expectations = [XCTestExpectation]()
 
         for i in iterations {
+            let exp = expectation(description: #function+"_i")
+            expectations.append(exp)
+
             if i.isMultiple(of: 2) {
                 expected.append(i)
             }
-            let exp = expectation(description: #function+"_i")
-            expectations.append(exp)
 
             let task: TestTask = TestTask(i: i) {
                 results.append($0)
@@ -100,7 +101,7 @@ final class TaskQueueTests: XCTestCase {
         XCTAssertTrue(expected != results) //items are returned in a different order
         XCTAssertEqual(expected.sorted(), results.sorted()) // specific items are returned
         XCTAssertEqual(expected.count, results.count) // all items are returned
-        XCTAssertEqual(10, results.count) // all items are returned
+        XCTAssertEqual(5, results.count) // all items are returned
     }
 }
 

--- a/SwiftAdditions/Tests/WrappedSequenceTests.swift
+++ b/SwiftAdditions/Tests/WrappedSequenceTests.swift
@@ -1,0 +1,126 @@
+import XCTest
+@testable import Additions
+import Foundation
+
+final class WrappedSequenceTests: XCTestCase {
+    
+    var random: Double {
+        Double.random(in: 0.000001...0.00001)
+    }
+
+    func testSequencePerformance() async throws {
+
+        let iterations = 10000
+        var expected = [Int]()
+
+        let sequeunce = WrappedSequence<Int>()
+
+        for i in 0...iterations {
+            sequeunce.addTask {
+                await self.executeBlock(value: i)
+            }
+            expected.append(i)
+        }
+
+        let results = await sequeunce.getResults().compactMap { try? $0.get() }
+        XCTAssertEqual(results, expected)
+    }
+
+    func testSequenceCancelations() async throws {
+        let iterations = 1000
+        var expected = [Int]()
+        let sequeunce = WrappedSequence<Int>()
+
+        for i in 0...iterations {
+            if i.isMultiple(of: 2) {
+                expected.append(i)
+            }
+            let task = sequeunce.addTask {
+                await self.executeBlock(value: i)
+            }
+
+            if i.isMultiple(of: 2) == false {
+                task.cancel()
+            }
+        }
+
+        let results = await sequeunce.getResults().compactMap { try? $0.get() }
+        XCTAssertEqual(results, expected)
+    }
+
+    func testSequenceCancelsFirstElementButReceivesSecond() async throws {
+
+        let sequeunce = WrappedSequence<Int>()
+
+        let task1 = sequeunce.addTask {
+            await self.executeBlock(value: 1, delay: 0.2)
+        }
+
+        sequeunce.addTask {
+            await self.executeBlock(value: 2, delay: 0.2)
+        }
+
+        task1.cancel()
+
+        let results = await sequeunce.getResults().compactMap { try? $0.get() }
+
+        XCTAssertEqual(results, [2])
+    }
+
+    func testSequenceCanReceiveEventsInVariousMoments() async throws {
+
+        let sequeunce = WrappedSequence<Int>()
+
+        let task1 = sequeunce.addTask {
+            await self.executeBlock(value: 1, delay: 0.2)
+        }
+
+        sequeunce.addTask {
+            await self.executeBlock(value: 2, delay: 0.2)
+        }
+
+        task1.cancel()
+
+        var results = await sequeunce.getValues()
+        sequeunce.removeDone()
+
+        sequeunce.addTask {
+            await self.executeBlock(value: 3, delay: 0.2)
+        }
+
+        let task4 = sequeunce.addTask {
+            await self.executeBlock(value: 4, delay: 0.2)
+        }
+
+        task4.cancel()
+
+        let next = await sequeunce.getValues()
+        results.append(contentsOf: next)
+
+        XCTAssertEqual(results, [2, 3])
+    }
+
+    func executeBlock(value: Int, delay: Double? = nil) async -> Result<Int, Error> {
+        if Task.isCancelled {
+            return .failure(CancellationError())
+        }
+
+        try? await Task.sleep(for: delay ?? self.random)
+        if Task.isCancelled {
+            return .failure(CancellationError())
+        }
+
+        return .success(value)
+    }
+}
+
+//MARK: - Test helpers.
+private extension WrappedSequence {
+    func removeDone() {
+        tasks.removeAll { $0.isDone }
+    }
+
+    func getValues() async -> [U] {
+        await getResults().compactMap { try? $0.get() }
+    }
+}

--- a/SwiftAdditions/Tests/WrappedTaskGroupTests.swift
+++ b/SwiftAdditions/Tests/WrappedTaskGroupTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+import Additions
+
+final class WrappedTaskGroupTests: XCTestCase {
+
+    var random: Double {
+        Double.random(in: 0.000001...0.00001)
+    }
+
+    func testConcurrentQueueItems() async throws {
+
+        let iterations = 10000
+        var expected = [Int]()
+        var expectations = [XCTestExpectation]()
+        let results = try await WrappedTaskGroup.run { queue in
+            for i in 1...iterations {
+                let exp = expectation(description: #function+"_i")
+                expectations.append(exp)
+                queue.addTask {
+                    let result = try await self.executeBlock(value: i)
+                    exp.fulfill()
+                    return result
+                }
+                expected.append(i)
+            }
+        }
+
+        await fulfillment(of: expectations)
+
+        XCTAssertEqual(results.count, expected.count) // all items are returned
+        XCTAssertNotEqual(results, expected) //items are returned in a different order
+        XCTAssertEqual(results.sorted(), expected.sorted()) // specific items are returned
+    }
+
+    func executeBlock(value: Int) async throws -> Int {
+        try await Task.sleep(for: self.random)
+        return value
+    }
+}


### PR DESCRIPTION
`TaskQueue` has proven to be highly flaky under the slightest of stress, add more than 5-6 operations with async blocks and tests start failing or the runtime crashing.

Enter `WrappedSequence` and `WrappedTaskGroup`. 

`WrappedSequence` is able to handle async tasks in FIFO order, supporting cancellations.

`WrappedTaskGroup` is a simple wrapper around `withThrowingTaskGroup` to simplify language syntax